### PR TITLE
Add option to generate QR code for entity when inspecting it

### DIFF
--- a/bw.go
+++ b/bw.go
@@ -321,9 +321,14 @@ func main() {
 			Action:  cli.ActionFunc(actionInspect),
 			Flags: []cli.Flag{
 				cli.BoolFlag{
-					Name:  "publish, p",
-					Usage: "publish inspected objects to the registry",
-				}, bflag,
+					Name:		"publish, p",
+					Usage:	"publish inspected objects to the registry",
+				},
+				cli.BoolFlag{
+					Name:		"qrcode, q",
+					Usage:	"makes QR Codes for entities with available siging keys",
+				},
+				bflag,
 			},
 		},
 		{

--- a/cli.go
+++ b/cli.go
@@ -1118,7 +1118,9 @@ func actionInspect(c *cli.Context) error {
 				entity := roi.(*objects.Entity)
 				signingblob := entity.GetSigningBlob()
 				if signingblob != nil {
-					err := qrcode.WriteFile(string([]byte{objects.ROEntityWKey}) + string(signingblob), qrcode.Medium, 512, fmt.Sprintf("%s.png", qrd.name))
+					binarydata := append([]byte{objects.ROEntityWKey}, signingblob...)
+					towrite := base64.StdEncoding.EncodeToString(binarydata)
+					err := qrcode.WriteFile(towrite, qrcode.Medium, 512, fmt.Sprintf("%s.png", qrd.name))
 					if err != nil {
 						fmt.Printf("Could not encode QR Code and write to file: %v\n", err)
 						os.Exit(1)

--- a/cli.go
+++ b/cli.go
@@ -1118,9 +1118,10 @@ func actionInspect(c *cli.Context) error {
 				entity := roi.(*objects.Entity)
 				signingblob := entity.GetSigningBlob()
 				if signingblob != nil {
-					err := qrcode.WriteFile(string([]byte{objects.ROEntityWKey}) + string(signingblob), qrcode.Medium, 256, fmt.Sprintf("%s.png", qrd.name))
+					err := qrcode.WriteFile(string([]byte{objects.ROEntityWKey}) + string(signingblob), qrcode.Medium, 512, fmt.Sprintf("%s.png", qrd.name))
 					if err != nil {
 						fmt.Printf("Could not encode QR Code and write to file: %v\n", err)
+						os.Exit(1)
 					}
 				}
 			}


### PR DESCRIPTION
If you want I can also add the option to specify how much error correction to put into the QR code, which would affect the size. For now I default to the "Medium" setting.
