### PR TITLE
Store filepaths in generated configuration file using forward slashes

### DIFF
--- a/internal/core/configparser.go
+++ b/internal/core/configparser.go
@@ -19,6 +19,7 @@ package core
 
 import (
 	"os"
+	"path/filepath"
 
 	log "github.com/cihub/seelog"
 	"github.com/scalingdata/gcfg"
@@ -43,18 +44,16 @@ type BWConfig struct {
 // it will default to "bw2.ini" in the current directory
 func LoadConfig(filename string) *BWConfig {
 	rv := &BWConfig{}
-	if filename != "" {
-		err := gcfg.ReadFileInto(rv, filename)
-		if err != nil {
-			log.Criticalf("Could not load specified config file: %v", err)
-			os.Exit(1)
-		}
-	} else {
-		err := gcfg.ReadFileInto(rv, "bw2.ini")
-		if err != nil {
-			log.Criticalf("Could not load default config file: %v", err)
-			os.Exit(1)
-		}
+	if filename == "" {
+		filename = "bw2.ini"
 	}
+	err := gcfg.ReadFileInto(rv, filename)
+	if err != nil {
+		log.Criticalf("Could not load specified config file: %v", err)
+		os.Exit(1)
+	}
+	rv.Router.Entity = filepath.FromSlash(rv.Router.Entity)
+	rv.Router.DB = filepath.FromSlash(rv.Router.DB)
+	rv.Router.LogPath = filepath.FromSlash(rv.Router.LogPath)
 	return rv
 }

--- a/makeconf.go
+++ b/makeconf.go
@@ -69,9 +69,9 @@ func makeConf(c *cli.Context) error {
 	file := []string{
 		("# generated for " + util.BW2Version + "\n"),
 		("[router]\n"),
-		("Entity=" + entfile + "\n"),
-		("DB=" + dbpath + "\n"),
-		("LogPath=" + lpath + "\n"),
+		("Entity=" + filepath.ToSlash(entfile) + "\n"),
+		("DB=" + filepath.ToSlash(dbpath) + "\n"),
+		("LogPath=" + filepath.ToSlash(lpath) + "\n"),
 		("[native]\n"),
 		("ListenOn=:4514\n"),
 		("[oob]\n"),


### PR DESCRIPTION
This works around the fact that the configuration file parser cannot parse
configuration files containing back slashes, which causes problems for
Windows filepaths.
